### PR TITLE
Convert to HipChat API v2 and python3

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,7 +6,7 @@
     "keywords": ["opbeat", "hipchat", "error logging", "release tracking"],
     "success_url": "/setup",
     "env": {
-        "HIPCHAT_AUTH_TOKEN": null,
-        "HIPCHAT_ROOM_ID": null
+        "HIPCHAT_ROOM_AUTH_TOKEN": null,
+        "HIPCHAT_ROOM": null
     }
 }


### PR DESCRIPTION
Hello! This patch uses HipChat's new API version as V1 is getting deprecated.

It requires a room token, instead of the old notification type [(docs)](https://www.hipchat.com/docs/apiv2/method/send_room_notification). Therefore I opted to change the names of the env vars needed as well, as you can pass a room name *or* id, and the auth token is a room token as mentioned before.

I also made `main.py` python3 compatible :)